### PR TITLE
Populate the `InstalledPackageDetail.LatestVersion` field.

### DIFF
--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server.go
@@ -738,13 +738,19 @@ func (s *Server) GetInstalledPackageDetail(ctx context.Context, request *corev1.
 		return nil, status.Errorf(codes.Internal, "Error while fetching related chart: %v", err)
 	}
 	if len(charts) == 1 {
-		log.Errorf("Got chart: %+v", charts[0])
 		installedPkgDetail.AvailablePackageRef = &corev1.AvailablePackageReference{
 			Identifier: charts[0].ID,
 			Plugin:     GetPluginDetail(),
 		}
 		if charts[0].Repo != nil {
 			installedPkgDetail.AvailablePackageRef.Context = &corev1.Context{Namespace: charts[0].Repo.Namespace}
+		}
+		if len(charts[0].ChartVersions) > 0 {
+			cv := charts[0].ChartVersions[0]
+			installedPkgDetail.LatestVersion = &corev1.PackageAppVersion{
+				PkgVersion: cv.Version,
+				AppVersion: cv.AppVersion,
+			}
 		}
 	}
 

--- a/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
+++ b/cmd/kubeapps-apis/plugins/helm/packages/v1alpha1/server_test.go
@@ -2008,6 +2008,10 @@ func TestGetInstalledPackageDetail(t *testing.T) {
 						PkgVersion: releaseVersion,
 						AppVersion: DefaultAppVersion,
 					},
+					LatestVersion: &corev1.PackageAppVersion{
+						PkgVersion: releaseVersion,
+						AppVersion: DefaultAppVersion,
+					},
 					ValuesApplied:         releaseValues,
 					PostInstallationNotes: releaseNotes,
 					Status: &corev1.InstalledPackageStatus{
@@ -2158,7 +2162,8 @@ func chartAssetForReleaseStub(rel *releaseStub) *models.Chart {
 		})
 	}
 	chartVersions = append(chartVersions, models.ChartVersion{
-		Version: rel.chartVersion,
+		Version:    rel.chartVersion,
+		AppVersion: DefaultAppVersion,
 	})
 
 	return &models.Chart{


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Description of the change

A small follow-on from the mechanical change in #3283, populating the `InstalledPackageDetail.latestVersion`

In real life test:

```
$ grpcurl -plaintext -d '{"installed_package_ref": {"context": {"namespace": "default"}, "identifier": "test-apache"}}' localhost:8080  kubeappsapis.plugins.helm.packages.v1alpha1.HelmPackagesService.GetInstalledPackageDetail
{
  "installedPackageDetail": {
    "installedPackageRef": {
      "context": {
        "namespace": "default"
      },
      "identifier": "test-apache"
    },
    "pkgVersionReference": {
      "version": "8.5.4"
    },
    "name": "test-apache",
    "currentVersion": {
      "pkgVersion": "8.5.4",
      "appVersion": "2.4.46"
    },
    "valuesApplied": ...,
    "status": {
      "ready": true,
      "reason": "STATUS_REASON_INSTALLED",
      "userReason": "deployed"
    },
    "postInstallationNotes": ...,
    "availablePackageRef": {
      "context": {
        "namespace": "kubeapps"
      },
      "identifier": "bitnami/apache",
      "plugin": {
        "name": "helm.packages",
        "version": "v1alpha1"
      }
    },
    "latestVersion": {
      "pkgVersion": "8.6.1",
      "appVersion": "2.4.48"
    }
  }
}
```

### Benefits

UI can use the info as required.

### Possible drawbacks

None

### Applicable issues

  - Ref #3165

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
